### PR TITLE
Limit classification map output

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,32 @@ The performance of our proposed SDST in HSI datasets.
 python main.py
 ```
 
+## Dataset Preparation
+
+The training code expects the hyperspectral datasets in a folder named `Dataset/`:
+
+```
+Dataset/
+├── Botswana.mat
+├── Botswana_gt.mat
+├── Indian_pines_corrected.mat
+├── Indian_pines_gt.mat
+├── Salinas.mat
+├── HoustonU.mat
+└── ...
+```
+
+Please download the required `.mat` files and place them under this directory.
+If the files are missing, running `main.py` will fail with `FileNotFoundError`.
+
+### CPU Training
+
+GPU usage is enabled by default. To run on CPU, start the script with:
+
+```
+python main.py --cuda False
+```
+
 
 # Citation
 If you use code or datasets in this repository for your research, please cite our paper.

--- a/classic_methods.py
+++ b/classic_methods.py
@@ -1,0 +1,54 @@
+import numpy as np
+from utils import eva
+
+
+def run_dbscan(img, gt):
+    """Run cuML DBSCAN on hyperspectral image."""
+    try:
+        import cupy as cp
+        from cuml.cluster import DBSCAN
+    except Exception as e:
+        print("cuML not available:", e)
+        return
+    X = cp.asarray(img.reshape(-1, img.shape[2]).astype(np.float32))
+    labels = DBSCAN().fit_predict(X)
+    eva(gt.reshape(-1), cp.asnumpy(labels))
+
+
+def run_kmeans(img, gt, n_clusters):
+    """Run cuML KMeans."""
+    try:
+        import cupy as cp
+        from cuml.cluster import KMeans
+    except Exception as e:
+        print("cuML not available:", e)
+        return
+    X = cp.asarray(img.reshape(-1, img.shape[2]).astype(np.float32))
+    labels = KMeans(n_clusters=n_clusters).fit_predict(X)
+    eva(gt.reshape(-1), cp.asnumpy(labels))
+
+
+def run_pca_kmeans(img, gt, n_clusters, n_components=30):
+    """Run cuML PCA followed by KMeans."""
+    try:
+        import cupy as cp
+        from cuml.cluster import KMeans
+        from cuml.decomposition import PCA
+    except Exception as e:
+        print("cuML not available:", e)
+        return
+    X = cp.asarray(img.reshape(-1, img.shape[2]).astype(np.float32))
+    pca = PCA(n_components=min(n_components, img.shape[2]))
+    X_pca = pca.fit_transform(X)
+    labels = KMeans(n_clusters=n_clusters).fit_predict(X_pca)
+    eva(gt.reshape(-1), cp.asnumpy(labels))
+
+
+def run_classic_methods(img, gt, n_clusters):
+    """Evaluate several classic ML methods."""
+    print("\n=== cuML DBSCAN ===")
+    run_dbscan(img, gt)
+    print("\n=== cuML KMeans ===")
+    run_kmeans(img, gt, n_clusters)
+    print("\n=== cuML PCA + KMeans ===")
+    run_pca_kmeans(img, gt, n_clusters)

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from calcu_graph import *
 import opt
 from train_SDST import train
 from utils import setup_seed
+from classic_methods import run_classic_methods
 
 p = Processor()
 torch.cuda.empty_cache()
@@ -51,7 +52,7 @@ elif DATASET == 'salinas':
     n_seg = 1000
     seed = 452
     data_mat = sio.loadmat(
-        '.Dataset/Salinas.mat')
+        './Dataset/Salinas.mat')
     data = data_mat['salinas_corrected']
     gt = data_mat['salinas_gt']
     dataset_name = "salinas"  # data_name
@@ -61,12 +62,12 @@ elif DATASET == 'HoustonU':
     n_seg = 1000
     seed = 458
     data_mat = sio.loadmat(
-        '.Dataset/HoustonU.mat')
+        './Dataset/HoustonU.mat')
     data = data_mat['HoustonU']
     gt = data_mat['HoustonU_GT']
     dataset_name = "HoustonU"  # data_name
     class_count = 15  # calss_num
-load_path = ".Dataset/" + dataset_name
+load_path = "./Dataset/" + dataset_name
 ori_gt = gt
 img = p.std_norm(data)
 
@@ -118,3 +119,5 @@ opt.args.width = img.shape[1]
 for curr_seed in range(3150, 3310):
     setup_seed(curr_seed)
     train(Q, gt, prt_img0, img, Adj, bias, opt.args.k, opt)
+
+run_classic_methods(img, gt, class_count)

--- a/utils.py
+++ b/utils.py
@@ -16,7 +16,10 @@ from torch.nn import functional as F
 import matplotlib.colors as mcolors
 
 os.environ["CUDA_DEVICE_ORDER"] = 'PCI_BUS_ID'
-device = torch.device("cuda:{}".format(opt.args.k) if torch.cuda.is_available() else "cpu")
+if opt.args.cuda and torch.cuda.is_available():
+    device = torch.device(f"cuda:{opt.args.k}")
+else:
+    device = torch.device("cpu")
 
 
 class KMEANS:


### PR DESCRIPTION
## Summary
- support `--cuda False` to fall back to CPU
- fix dataset file paths
- remove unnecessary graph retention
- generate classification map only once after training
- added classic ML baselines using cuML
- call baselines from `main.py`
- document dataset preparation and CPU usage in README

## Testing
- `python -m py_compile train_SDST.py utils.py main.py opt.py Preprocessing.py calcu_graph.py classic_methods.py`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_68756062a2848331ad2b1ee960032d98